### PR TITLE
CB4UCentralManagerのIntPtrを扱う部分をSafeCB4UCentralManagerHandleに分離

### DIFF
--- a/Assets/SamplePlugin/Runtime/CoreBluetooth/NativeMethods.cs
+++ b/Assets/SamplePlugin/Runtime/CoreBluetooth/NativeMethods.cs
@@ -35,7 +35,7 @@ namespace CoreBluetooth
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void cb4u_central_manager_register_handlers(
-            IntPtr centralPtr,
+            SafeCB4UCentralManagerHandle centralPtr,
             CB4UCentralManagerDidUpdateStateHandler didUpdateStateHandler,
             CB4UCentralManagerDidDiscoverPeripheralHandler didDiscoverPeripheralHandler,
             CB4UCentralManagerDidConnectPeripheralHandler didConnectPeripheralHandler,
@@ -51,7 +51,7 @@ namespace CoreBluetooth
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int cb4u_central_manager_retrieve_peripherals_with_identifiers(
-            IntPtr centralPtr,
+            SafeCB4UCentralManagerHandle centralPtr,
             [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr, SizeParamIndex = 2)] string[] peripheralIds,
             int peripheralIdsCount,
             [MarshalAs(UnmanagedType.LPStr), Out] StringBuilder sb,
@@ -60,52 +60,52 @@ namespace CoreBluetooth
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void cb4u_central_manager_scan_for_peripherals(
-            IntPtr centralPtr,
+            SafeCB4UCentralManagerHandle centralPtr,
             [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr, SizeParamIndex = 2)] string[] serviceUUIDs,
             int serviceUUIDsCount
         );
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void cb4u_central_manager_stop_scan(IntPtr centralPtr);
+        internal static extern void cb4u_central_manager_stop_scan(SafeCB4UCentralManagerHandle centralPtr);
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        internal static extern bool cb4u_central_manager_is_scanning(IntPtr centralPtr);
+        internal static extern bool cb4u_central_manager_is_scanning(SafeCB4UCentralManagerHandle centralPtr);
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int cb4u_central_manager_connect_peripheral(IntPtr centralPtr, [MarshalAs(UnmanagedType.LPStr), In] string peripheralId);
+        internal static extern int cb4u_central_manager_connect_peripheral(SafeCB4UCentralManagerHandle centralPtr, [MarshalAs(UnmanagedType.LPStr), In] string peripheralId);
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int cb4u_central_manager_cancel_peripheral_connection(IntPtr centralPtr, [MarshalAs(UnmanagedType.LPStr), In] string peripheralId);
+        internal static extern int cb4u_central_manager_cancel_peripheral_connection(SafeCB4UCentralManagerHandle centralPtr, [MarshalAs(UnmanagedType.LPStr), In] string peripheralId);
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int cb4u_central_manager_peripheral_name(IntPtr centralPtr, [MarshalAs(UnmanagedType.LPStr), In] string peripheralId, [MarshalAs(UnmanagedType.LPStr), Out] StringBuilder sb, int sbSize);
+        internal static extern int cb4u_central_manager_peripheral_name(SafeCB4UCentralManagerHandle centralPtr, [MarshalAs(UnmanagedType.LPStr), In] string peripheralId, [MarshalAs(UnmanagedType.LPStr), Out] StringBuilder sb, int sbSize);
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int cb4u_central_manager_peripheral_state(IntPtr centralPtr, [MarshalAs(UnmanagedType.LPStr), In] string peripheralId);
+        internal static extern int cb4u_central_manager_peripheral_state(SafeCB4UCentralManagerHandle centralPtr, [MarshalAs(UnmanagedType.LPStr), In] string peripheralId);
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int cb4u_central_manager_peripheral_read_rssi(IntPtr centralPtr, [MarshalAs(UnmanagedType.LPStr), In] string peripheralId);
+        internal static extern int cb4u_central_manager_peripheral_read_rssi(SafeCB4UCentralManagerHandle centralPtr, [MarshalAs(UnmanagedType.LPStr), In] string peripheralId);
 
         // characteristicなため名前central_managerではなくperipheralの方が適切な気はする。
         // しかし、peripheral_managerと区別するためにcentral_managerに寄せた方がいい気もする。
         // とりあえずcentral_managerに寄せておいてあとで検討する。
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int cb4u_central_manager_characteristic_properties(IntPtr centralPtr, [MarshalAs(UnmanagedType.LPStr), In] string peripheralId, [MarshalAs(UnmanagedType.LPStr), In] string serviceId, [MarshalAs(UnmanagedType.LPStr), In] string characteristicId);
+        internal static extern int cb4u_central_manager_characteristic_properties(SafeCB4UCentralManagerHandle centralPtr, [MarshalAs(UnmanagedType.LPStr), In] string peripheralId, [MarshalAs(UnmanagedType.LPStr), In] string serviceId, [MarshalAs(UnmanagedType.LPStr), In] string characteristicId);
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int cb4u_peripheral_discover_services(IntPtr centralPtr, [MarshalAs(UnmanagedType.LPStr), In] string peripheralId, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr, SizeParamIndex = 3)] string[] serviceUUIDs, int serviceUUIDsCount);
+        internal static extern int cb4u_peripheral_discover_services(SafeCB4UCentralManagerHandle centralPtr, [MarshalAs(UnmanagedType.LPStr), In] string peripheralId, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr, SizeParamIndex = 3)] string[] serviceUUIDs, int serviceUUIDsCount);
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int cb4u_peripheral_discover_characteristics(IntPtr centralPtr, [MarshalAs(UnmanagedType.LPStr), In] string peripheralId, [MarshalAs(UnmanagedType.LPStr), In] string serviceId, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr, SizeParamIndex = 4)] string[] characteristicUUIDs, int characteristicUUIDsCount);
+        internal static extern int cb4u_peripheral_discover_characteristics(SafeCB4UCentralManagerHandle centralPtr, [MarshalAs(UnmanagedType.LPStr), In] string peripheralId, [MarshalAs(UnmanagedType.LPStr), In] string serviceId, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr, SizeParamIndex = 4)] string[] characteristicUUIDs, int characteristicUUIDsCount);
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int cb4u_peripheral_read_value_for_characteristic(IntPtr centralPtr, [MarshalAs(UnmanagedType.LPStr), In] string peripheralId, [MarshalAs(UnmanagedType.LPStr), In] string serviceId, [MarshalAs(UnmanagedType.LPStr), In] string characteristicId);
+        internal static extern int cb4u_peripheral_read_value_for_characteristic(SafeCB4UCentralManagerHandle centralPtr, [MarshalAs(UnmanagedType.LPStr), In] string peripheralId, [MarshalAs(UnmanagedType.LPStr), In] string serviceId, [MarshalAs(UnmanagedType.LPStr), In] string characteristicId);
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int cb4u_peripheral_write_value_for_characteristic(IntPtr centralPtr, [MarshalAs(UnmanagedType.LPStr), In] string peripheralId, [MarshalAs(UnmanagedType.LPStr), In] string serviceId, [MarshalAs(UnmanagedType.LPStr), In] string characteristicId, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1, SizeParamIndex = 5)] byte[] dataBytes, int dataLength, int writeType);
+        internal static extern int cb4u_peripheral_write_value_for_characteristic(SafeCB4UCentralManagerHandle centralPtr, [MarshalAs(UnmanagedType.LPStr), In] string peripheralId, [MarshalAs(UnmanagedType.LPStr), In] string serviceId, [MarshalAs(UnmanagedType.LPStr), In] string characteristicId, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1, SizeParamIndex = 5)] byte[] dataBytes, int dataLength, int writeType);
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int cb4u_peripheral_set_notify_value_for_characteristic(IntPtr centralPtr, [MarshalAs(UnmanagedType.LPStr), In] string peripheralId, [MarshalAs(UnmanagedType.LPStr), In] string serviceId, [MarshalAs(UnmanagedType.LPStr), In] string characteristicId, [MarshalAs(UnmanagedType.I1)] bool enabled);
+        internal static extern int cb4u_peripheral_set_notify_value_for_characteristic(SafeCB4UCentralManagerHandle centralPtr, [MarshalAs(UnmanagedType.LPStr), In] string peripheralId, [MarshalAs(UnmanagedType.LPStr), In] string serviceId, [MarshalAs(UnmanagedType.LPStr), In] string characteristicId, [MarshalAs(UnmanagedType.I1)] bool enabled);
     }
 }

--- a/Assets/SamplePlugin/Runtime/CoreBluetooth/SafeCB4UCentralManagerHandle.cs
+++ b/Assets/SamplePlugin/Runtime/CoreBluetooth/SafeCB4UCentralManagerHandle.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace CoreBluetooth
+{
+    internal class SafeCB4UCentralManagerHandle : SafeHandle
+    {
+        static Dictionary<IntPtr, CBCentralManager> centralManagerMap = new Dictionary<IntPtr, CBCentralManager>();
+        SafeCB4UCentralManagerHandle(IntPtr handle) : base(handle, true) { }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        internal static SafeCB4UCentralManagerHandle Create(CBCentralManager centralManager)
+        {
+            var handle = NativeMethods.cb4u_central_manager_new();
+            var instance = new SafeCB4UCentralManagerHandle(handle);
+            centralManagerMap.Add(handle, centralManager);
+            return instance;
+        }
+
+        internal static bool TryGetCBCentralManager(IntPtr handle, out CBCentralManager centralManager)
+        {
+            return centralManagerMap.TryGetValue(handle, out centralManager);
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            centralManagerMap.Remove(handle);
+            NativeMethods.cb4u_central_manager_release(handle);
+            return true;
+        }
+    }
+}

--- a/Assets/SamplePlugin/Runtime/CoreBluetooth/SafeCB4UCentralManagerHandle.cs
+++ b/Assets/SamplePlugin/Runtime/CoreBluetooth/SafeCB4UCentralManagerHandle.cs
@@ -15,6 +15,7 @@ namespace CoreBluetooth
         {
             var handle = NativeMethods.cb4u_central_manager_new();
             var instance = new SafeCB4UCentralManagerHandle(handle);
+            RegisterHandlers(instance);
             centralManagerMap.Add(handle, centralManager);
             return instance;
         }
@@ -22,6 +23,101 @@ namespace CoreBluetooth
         internal static bool TryGetCBCentralManager(IntPtr handle, out CBCentralManager centralManager)
         {
             return centralManagerMap.TryGetValue(handle, out centralManager);
+        }
+
+        static void CallInstanceMethod(IntPtr centralPtr, Action<CBCentralManager> action)
+        {
+            if (!SafeCB4UCentralManagerHandle.TryGetCBCentralManager(centralPtr, out var instance))
+            {
+                UnityEngine.Debug.LogError("CBCentralManager instance not found.");
+                return;
+            }
+
+            action(instance);
+        }
+
+        static void RegisterHandlers(SafeCB4UCentralManagerHandle handle)
+        {
+            NativeMethods.cb4u_central_manager_register_handlers(
+                handle,
+                OnDidUpdateState,
+                OnDidDiscoverPeripheral,
+                OnDidConnectPeripheral,
+                OnDidFailToConnectPeripheral,
+                OnDidDisconnectPeripheral,
+                OnDidDiscoverServices,
+                OnDidDiscoverCharacteristics,
+                OnDidUpdateValueForCharacteristic,
+                OnDidWriteValueForCharacteristic,
+                OnDidUpdateNotificationStateForCharacteristic,
+                OnDidReadRSSI
+            );
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UCentralManagerDidUpdateStateHandler))]
+        internal static void OnDidUpdateState(IntPtr centralPtr, CBManagerState state)
+        {
+            CallInstanceMethod(centralPtr, instance => instance.OnDidUpdateState(state));
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UCentralManagerDidDiscoverPeripheralHandler))]
+        internal static void OnDidDiscoverPeripheral(IntPtr centralPtr, IntPtr peripheralIdPtr, IntPtr peripheralNamePtr)
+        {
+            CallInstanceMethod(centralPtr, instance => instance.OnDidDiscoverPeripheral(peripheralIdPtr, peripheralNamePtr));
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UCentralManagerDidConnectPeripheralHandler))]
+        internal static void OnDidConnectPeripheral(IntPtr centralPtr, IntPtr peripheralIdPtr)
+        {
+            CallInstanceMethod(centralPtr, instance => instance.OnDidConnectPeripheral(peripheralIdPtr));
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UCentralManagerDidFailToConnectPeripheralHandler))]
+        internal static void OnDidFailToConnectPeripheral(IntPtr centralPtr, IntPtr peripheralIdPtr, int errorCode)
+        {
+            CallInstanceMethod(centralPtr, instance => instance.OnDidFailToConnectPeripheral(peripheralIdPtr, errorCode));
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UCentralManagerDidDisconnectPeripheralHandler))]
+        internal static void OnDidDisconnectPeripheral(IntPtr centralPtr, IntPtr peripheralIdPtr, int errorCode)
+        {
+            CallInstanceMethod(centralPtr, instance => instance.OnDidDisconnectPeripheral(peripheralIdPtr, errorCode));
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralDidDiscoverServicesHandler))]
+        internal static void OnDidDiscoverServices(IntPtr centralPtr, IntPtr peripheralIdPtr, IntPtr commaSeparatedServiceIdsPtr, int errorCode)
+        {
+            CallInstanceMethod(centralPtr, instance => instance.OnDidDiscoverServices(peripheralIdPtr, commaSeparatedServiceIdsPtr, errorCode));
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralDidDiscoverCharacteristicsHandler))]
+        internal static void OnDidDiscoverCharacteristics(IntPtr centralPtr, IntPtr peripheralIdPtr, IntPtr serviceIdPtr, IntPtr commaSeparatedCharacteristicIdsPtr, int errorCode)
+        {
+            CallInstanceMethod(centralPtr, instance => instance.OnDidDiscoverCharacteristics(peripheralIdPtr, serviceIdPtr, commaSeparatedCharacteristicIdsPtr, errorCode));
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralDidUpdateValueForCharacteristicHandler))]
+        internal static void OnDidUpdateValueForCharacteristic(IntPtr centralPtr, IntPtr peripheralIdPtr, IntPtr serviceIdPtr, IntPtr characteristicIdPtr, IntPtr valuePtr, int valueLength, int errorCode)
+        {
+            CallInstanceMethod(centralPtr, instance => instance.OnDidUpdateValueForCharacteristic(peripheralIdPtr, serviceIdPtr, characteristicIdPtr, valuePtr, valueLength, errorCode));
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralDidWriteValueForCharacteristicHandler))]
+        internal static void OnDidWriteValueForCharacteristic(IntPtr centralPtr, IntPtr peripheralIdPtr, IntPtr serviceIdPtr, IntPtr characteristicIdPtr, int errorCode)
+        {
+            CallInstanceMethod(centralPtr, instance => instance.OnDidWriteValueForCharacteristic(peripheralIdPtr, serviceIdPtr, characteristicIdPtr, errorCode));
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralDidUpdateNotificationStateForCharacteristicHandler))]
+        internal static void OnDidUpdateNotificationStateForCharacteristic(IntPtr centralPtr, IntPtr peripheralIdPtr, IntPtr serviceIdPtr, IntPtr characteristicIdPtr, int notificationState, int errorCode)
+        {
+            CallInstanceMethod(centralPtr, instance => instance.OnDidUpdateNotificationStateForCharacteristic(peripheralIdPtr, serviceIdPtr, characteristicIdPtr, notificationState, errorCode));
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralDidReadRSSIHandler))]
+        internal static void OnDidReadRSSI(IntPtr centralPtr, IntPtr peripheralIdPtr, int rssi, int errorCode)
+        {
+            CallInstanceMethod(centralPtr, instance => instance.OnDidReadRSSI(peripheralIdPtr, rssi, errorCode));
         }
 
         protected override bool ReleaseHandle()

--- a/Assets/SamplePlugin/Runtime/CoreBluetooth/SafeCB4UCentralManagerHandle.cs.meta
+++ b/Assets/SamplePlugin/Runtime/CoreBluetooth/SafeCB4UCentralManagerHandle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cdd2803038e0941d8b49744c65e31111
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 本PRについて
CB4UCentralManagerのIntPtrを触るのをSafeHandleに閉じ込めて分離

## 得られるメリット

- CBCentralManager.csが100行近くダイエットできた
- CB4UCentralManager(swift)のポインタを扱う役割をSafeCB4UCentralManagerHandleに分離できた。
- CBCentralManagerで、「Native側にインスタンスメソッドのdelegate渡せないから仕方なくstaticな辞書作ってる」のを知らなくて良くなった。

## メモ
SafeCB4UCentralManagerHandleとCBCentralManagerが相互依存になってるのはInterface切れば解消できるけど、
テスト書きづらかったら切るぐらいで良い気がする。